### PR TITLE
Reset viewport height on each request

### DIFF
--- a/notificaption.js
+++ b/notificaption.js
@@ -16,7 +16,7 @@ const s3 = new AWS.S3({
 
 const nightmare = Nightmare({
   show: false,
-  width: 1024,
+  width: 700,
   height: 768
 });
 
@@ -84,6 +84,7 @@ function *screenshot(data) {
   logger.info(`Generating screenshot for check ${checkID} from Emissary running at ${uri}`);
 
   const dimensions = yield nightmare
+    .viewport(700, 1)
     .goto(uri)
     .wait('body')
     .evaluate(function() {


### PR DESCRIPTION
We don't reinitialize Nightmare each time, so the viewport never gets reset between requests unless we do it explicitly. Previously, if you took a screenshot with a tall viewport and subsequently navigated to a shorter screen, the body dimensions won't shrink.
