### PR TITLE
Use check ID as static .json filename (until redirects figured out)

### DIFF
--- a/notificaption.js
+++ b/notificaption.js
@@ -60,8 +60,7 @@ function buildEmissaryURI(checkID) {
  */
 function dumpToFile(checkData, done) {
   const checkID = checkData.id;
-  const s3Key = generateS3Key(checkID);
-  const filename = `${s3Key}.json`;
+  const filename = `${checkID}.json`;
   const filePath = Path.resolve(`./tmp/checks/${filename}`);
 
   logger.info(`Dumping to file as ${filePath}`);
@@ -74,7 +73,7 @@ function dumpToFile(checkData, done) {
       logger.info(`Dumped to file as ${filePath}`);
       done(null, {
         check: checkData,
-        filename: s3Key
+        filename: generateS3Key(checkID)
       });
     }
   });


### PR DESCRIPTION
Since Emissary needs to make a request against Notificaption to grab the JSON, Emissary needs a static path to reference. Having a timestamp in there won't work, since Emissary can't "guess" it.

TODO: figure out if we can just redirect the post to the S3 URL. Less memory usage for the Notifcaption service, too. 
